### PR TITLE
Update bio with current role at Join and career timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
       </h1>
       <p>Ari is currently Head of Design at
         <a href="http://join.build">Join</a>,
-        a project management platform helping construction companies make better decisions, and still
-        <a href="http://punctual.coffee">slinging coffee</a> on the side.
+        a project management platform helping construction companies make better decisions.
       </p>
       <p>Previously, Ari built a global design team at
         <a href="http://blockdaemon.com">Blockdaemon</a>

--- a/index.html
+++ b/index.html
@@ -35,17 +35,19 @@
       <h1>Ari&nbsp;Zilnik leads high-performing design&nbsp;teams and enjoys niche 90's&nbsp;nostalgia. 
         <span class="emoji">📼</span>
       </h1>
-      <p>Ari is currently  <a href="http://punctual.coffee">slinging coffee</a> and advising some <a href="https://www.richardson.com">wonderful</a> <a href="http://join.build">clients</a>.</p>
-      <p>He has built a global design team at 
-        <a href="http://blockdaemon.com">Blockdaemon</a>, 
-        the world's foremost blockchain infrastructure company.  
+      <p>Ari is currently Head of Design at
+        <a href="http://join.build">Join</a>,
+        a project management platform helping construction companies make better decisions, and still
+        <a href="http://punctual.coffee">slinging coffee</a> on the side.
       </p>
-      <p>Before this, Ari founded a product design consultancy called 
-          <a href="http://heygravy.com">Gravy</a>, 
-          where he served as lead product designer for clients like 
-          <a href="https://www.trialspark.com/">TrialSpark</a>, 
-          <a href="https://www.veckta.com/">Veckta</a>, and  
-          <a href="https://gradle.com/">Gradle</a>.
+      <p>Previously, Ari built a global design team at
+        <a href="http://blockdaemon.com">Blockdaemon</a>
+        after they acquired his consultancy,
+        <a href="http://heygravy.com">Gravy</a>, in 2021.
+        At Gravy, he served as lead product designer for clients like
+        <a href="https://www.trialspark.com/">TrialSpark</a>,
+        <a href="https://www.veckta.com/">Veckta</a>, and
+        <a href="https://gradle.com/">Gradle</a>.
       </p>
       <p>Ari also worked as a product designer at 
         <a href="https://www.jet.com/">Jet.com</a> (acquired by Walmart) and  

--- a/index.html
+++ b/index.html
@@ -37,20 +37,20 @@
       </h1>
       <p>Ari is currently Head of Design at
         <a href="http://join.build">Join</a>,
-        a project management platform helping construction companies make better decisions.
+        a construction project management platform helping general contractors make better decisions.
       </p>
-      <p>Previously, Ari built a global design team at
+      <p>Before that, Ari built a global design team at
         <a href="http://blockdaemon.com">Blockdaemon</a>
         after they acquired his consultancy,
         <a href="http://heygravy.com">Gravy</a>, in 2021.
-        At Gravy, he served as lead product designer for clients like
-        <a href="https://www.trialspark.com/">TrialSpark</a>,
+        Through Gravy, he led product design for companies like
+        <a href="https://www.formation.bio/">Formation Bio</a> (formerly TrialSpark),
         <a href="https://www.veckta.com/">Veckta</a>, and
         <a href="https://gradle.com/">Gradle</a>.
       </p>
-      <p>Ari also worked as a product designer at 
-        <a href="https://www.jet.com/">Jet.com</a> (acquired by Walmart) and  
-        <a href="https://lab49.com/">Lab49</a>. 
+      <p>Ari also worked as a product designer at
+        <a href="https://www.jet.com/">Jet.com</a> (acquired by Walmart) and
+        <a href="https://lab49.com/">Lab49</a>.
       </p>
       <p>You can get in touch with an 
         <a href="mailto:&#119;&#101;&#098;&#115;&#105;&#116;&#101;&#064;&#122;&#105;&#108;&#110;&#105;&#107;&#046;&#099;&#111;&#109;">email</a> or a 


### PR DESCRIPTION
## Summary
Updated the portfolio bio to reflect current career status and provide a more accurate chronological narrative of professional experience.

## Changes
- **Current role**: Updated to reflect position as Head of Design at Join, a construction project management platform
- **Career narrative**: Reorganized the professional timeline for better clarity:
  - Moved Blockdaemon experience to "Before that" section
  - Clarified that Gravy was acquired by Blockdaemon in 2021
  - Updated client reference from "TrialSpark" to "Formation Bio (formerly TrialSpark)" to reflect company rebrand
  - Kept early career roles at Jet.com and Lab49 in chronological order
- **Removed outdated content**: Removed references to coffee slinging and generic client advisory work
- **Formatting**: Minor whitespace and line break adjustments for consistency

## Notes
The changes present a more professional and up-to-date narrative that accurately reflects the current role and provides context for the acquisition of Gravy by Blockdaemon.

https://claude.ai/code/session_013QqNTfYRjpwZucTyTftNGV