### PR TITLE
a11y: add focus-visible outline on links; fix blur CSS typo

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,6 +126,11 @@ a:visited {
 a:hover {
   color: rgba(255, 120, 120, 0.9);
 }
+a:focus-visible {
+  outline: 2px solid rgba(255, 168, 168, 0.8);
+  outline-offset: 3px;
+  border-radius: 1px;
+}
 
 
 /* Transitions for mobile */
@@ -146,7 +151,7 @@ a:hover {
 
   h1, p {
     text-shadow: 1px -2px 1px rgba(126, 255, 170, 0.15), -4px 0px 1px rgba(255, 0, 0, 0.15), 4px 0px 1px rgba(0, 194, 255, 0.10);
-    filter: blur(0.0x);
+    filter: blur(0px);
 
   }
 }


### PR DESCRIPTION
## What
- Added `a:focus-visible` rule with a pink outline matching the site's link color
- Fixed invalid CSS unit `blur(0.0x)` → `blur(0px)` in the mobile media query

## Why this helps
Keyboard users (and screen reader users navigating by Tab) had zero visual indicator of which link was focused — the site styled `a:hover` but completely skipped focus. Now tabbing through the page shows a clear 2px outline in the site's own link color, staying true to the retro aesthetic.

The `blur(0.0x)` typo was invalid CSS — `x` is not a valid unit for `blur()`. Browsers likely silently ignored it (treating it as no blur), but it's still a bug worth squashing.

## Before / After
**Before:** Tab through the page → no visible focus ring on any link  
**After:** Tab through the page → 2px pinkish outline appears around the focused link, offset 3px so it doesn't clip descenders

## Scope check
- Files changed: 1 (cap: 3)
- Lines changed: 7 (cap: 50)
- New deps: none
- Refactor: none

---
_Opened by the \`ux-coach\` scheduled task. Review, edit, or close at your discretion._