### PR TITLE
a11y: guard fade-in animation and transitions with prefers-reduced-motion

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,3 +155,14 @@ a:focus-visible {
 
   }
 }
+
+/* Respect reduced-motion preference: skip animation (body would stay invisible) and transitions */
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation: none;
+    opacity: 1;
+  }
+  h1, p, .container, body::before, .emoji {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What
Add a `@media (prefers-reduced-motion: reduce)` block to `style.css` that sets `animation: none; opacity: 1` on `body` and removes `transition` from all animated elements.

## Why this helps
`body` is set to `opacity: 0` and relies on the `fadeInAnimation` CSS animation to become visible. When a user (or OS) enables the reduced-motion preference, browsers skip or instant-complete animations — which means `body` stays invisible and the page appears blank. This is a real accessibility bug affecting users with vestibular disorders, epilepsy, or anyone who toggles "Reduce Motion" in their OS settings.

## Before / After
**Before:** Visitors with `prefers-reduced-motion: reduce` see a completely blank dark page — no text, no content.  
**After:** The page renders immediately at full opacity; CSS transitions on text, container, and the VHS overlay pseudo-element are also disabled so no motion occurs at all.

## Scope check
- Files: 1/3
- Lines added: 8/50
- New dependencies: none
- Refactor: none

_Opened by the ux-coach scheduled trigger._

---
_Generated by [Claude Code](https://claude.ai/code/session_013gUnb54CXB9e4RCRcy459z)_