### PR TITLE
seo: add og:image and twitter:image so social shares show the brand icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,13 @@
     <meta property="og:url" content="https://ari.zilnik.com/" />
     <meta property="og:title" content="Ari Zilnik - Product Design Leader" />
     <meta property="og:description" content="Player-coach product design leader who ships great products and enjoys niche 90's nostalgia. Currently Head of Design at Join." />
+    <meta property="og:image" content="https://ari.zilnik.com/android-chrome-384x384.png" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Ari Zilnik - Product Design Leader" />
     <meta name="twitter:description" content="Player-coach product design leader who ships great products and enjoys niche 90's nostalgia. Currently Head of Design at Join." />
+    <meta name="twitter:image" content="https://ari.zilnik.com/android-chrome-384x384.png" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com"> 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> 
@@ -37,7 +39,7 @@
     <meta name="msapplication-navbutton-color" content="#111111">
     <meta name="apple-mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-status-bar-style" content="#111111">
-    <link rel="stylesheet" href="style.css ">
+    <link rel="stylesheet" href="style.css">
 
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">


### PR DESCRIPTION
## What
Add `og:image` and `twitter:image` meta tags pointing to the existing `android-chrome-384x384.png`; also fix a trailing space in the stylesheet `href` attribute.

## Why this helps
The OG block was complete (type, url, title, description) but missing an image — so sharing ari.zilnik.com on Slack, LinkedIn, iMessage, or X produces a text-only card with no thumbnail. Adding the 384×384 brand icon completes the card and makes shares look intentional. The trailing space in `href="style.css "` is a typo; browsers normalize it, but it's wrong and worth cleaning up.

## Before / After
**Before:** Sharing ari.zilnik.com shows a bare link card with title and description but no image preview on any platform.  
**After:** Social clients that support OG/Twitter cards (Slack, LinkedIn, iMessage, X) display the brand icon as a square thumbnail alongside the title and description.

The stylesheet trailing space fix is invisible to users — purely a source cleanup.

## Scope check
- Files: 1/3
- Lines: 3 added, 1 fixed / 50
- Deps: none
- Refactor: none

_Opened by the ux-coach scheduled trigger._

---
_Generated by [Claude Code](https://claude.ai/code/session_016LmqUG4a7fTtYEBvqrRzkN)_